### PR TITLE
Update work assessment to stand alone and streamline definition handoff

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,11 @@
+Here are my thoughts:
+- The TDD for now should not be too detailed to significantly slow down development but should be at an appropriate design level to guide development.
+
+- Integration design - not so sure about intent behind the distinction between external and internal systems. All other systems would be external to this system right?
+
+- In general, the TDD should work closely with other deliverable artifacts such as but not limited to Operational Readiness and Security, Privacy and Compliance deliverables. What should go in the TDD should be the technical components that implement the requirements specified in the other artifacts.
+
+- Data Design - this has to work closely with [data_asset_specification.md](work delivery/data_governance_and_records_deliverables/data_asset_specification.md) and the corresponding owner/team of that artifact especially regarding the key data entities and structure. While the Data Asset artifact should be the source of truth regarding how key data entities should look like, development teams/leads may work together with the data governance team to improve the data specification. Regarding data storage, retention and archival, the TDD should complement [backup_restore_and_recovery_plan_specification.md](work delivery/operational_readiness_deliverables/backup_restore_and_recovery_plan_specification.md) artifact and vice versa.
+
+- Security Design - should work closly with [access_control_and_authorization_model_specification.md](work delivery/security_privacy_and_compliance_deliverables/access_control_and_authorization_model_specification.md) [compliance_and_regulatory_alignment_statement_specification.md](work delivery/security_privacy_and_compliance_deliverables/compliance_and_regulatory_alignment_statement_specification.md)  and [audit_and_monitoring_design_summary_specification.md](work delivery/security_privacy_and_compliance_deliverables/audit_and_monitoring_design_summary_specification.md) among others.
+

--- a/work delivery/work_assessment/initial_review_form.md
+++ b/work delivery/work_assessment/initial_review_form.md
@@ -1,6 +1,6 @@
 # Initial Review Form
 
-Use this form for the quick IT-side sanity check at the start of Stage 1 - Work Assessment.
+Use this form for the quick IT-side sanity check at the start of Work Assessment.
 
 Purpose:
 Decide whether the request is worth more assessment effort and broadly aligns with what the organization does.

--- a/work delivery/work_assessment/initial_review_specification.md
+++ b/work delivery/work_assessment/initial_review_specification.md
@@ -10,7 +10,7 @@ The intended outcome is that every new work idea receives an early triage decisi
 
 ## 2. When It Is Required
 
-This artifact is required at the start of Stage 1 - Work Assessment for any proposed planned work that may need governance, definition, or later authorization.
+This artifact is required at the start of Work Assessment for any proposed planned work that may need governance, definition, or later authorization.
 
 ## 3. Intended Readers and Users
 

--- a/work delivery/work_assessment/validation_assessment_form.md
+++ b/work delivery/work_assessment/validation_assessment_form.md
@@ -1,15 +1,15 @@
 # Validation Assessment Form
 
-Use this form for the middle step of Stage 1 - Work Assessment.
+Use this form for the middle step of Work Assessment.
 
 Purpose:
-Work with the requester's subject matter experts and immediate team to decide whether full business analysis is justified.
+Work with the requester's subject matter experts and immediate team to decide whether focused analysis is justified.
 
 Recommendation options:
 
 - Stop
 - Defer
-- Proceed to Full Business Analysis
+- Proceed to Focused Analysis
 
 ---
 
@@ -67,7 +67,7 @@ Guidance:
 
 ## 4. Current-State Snapshot
 
-What current systems, processes, constraints, dependencies, or prior attempts matter to understanding this request?
+What current systems, workflows, constraints, dependencies, or prior attempts matter to understanding this request?
 
 **Response:**  
 
@@ -83,7 +83,7 @@ What current systems, processes, constraints, dependencies, or prior attempts ma
 
 ---
 
-## 6. High-Level Functional Capabilities
+## 6. High-Level Requirements and Capabilities
 
 What must any viable solution be able to do?
 
@@ -92,6 +92,7 @@ Guidance:
 - describe what, not how
 - stay technology-agnostic
 - keep this at high level
+- note any material stakeholder requirements or non-negotiable conditions already visible
 
 **Response:**  
 
@@ -219,7 +220,7 @@ What gets worse, remains weak, or is lost if this is not pursued in the next 12 
 
 - [ ] Stop
 - [ ] Defer
-- [ ] Proceed to Full Business Analysis
+- [ ] Proceed to Focused Analysis
 
 **Relative priority:**  
 
@@ -239,7 +240,7 @@ What gets worse, remains weak, or is lost if this is not pursued in the next 12 
 
 - [ ] Stop
 - [ ] Defer
-- [ ] Proceed to Full Business Analysis
+- [ ] Proceed to Focused Analysis
 
 **Decision Date:**
 
@@ -251,7 +252,7 @@ What gets worse, remains weak, or is lost if this is not pursued in the next 12 
 
 ---
 
-## 13. Handoff Notes for Full Business Analysis
+## 13. Handoff Notes for Focused Analysis
 
 **Key context to carry forward:**  
 
@@ -261,4 +262,16 @@ What gets worse, remains weak, or is lost if this is not pursued in the next 12 
 
 **Stakeholder sensitivities / history:**  
 
+**Key stakeholder groups and their material needs or requirements:**  
+
 **Likely sponsor, Outcome Owner candidate, and Delivery Owner candidate signals (if known):**
+
+**Early signal on likely next definition artifact:**  
+
+- [ ] More likely to remain small enough for a Work Brief
+- [ ] More likely to require an Initiative Definition Document
+- [ ] Too early to judge confidently
+
+**Likely Acceptance Authority signal or ownership gap:**  
+
+**Operational / support ownership signals (if relevant):**  

--- a/work delivery/work_assessment/validation_assessment_specification.md
+++ b/work delivery/work_assessment/validation_assessment_specification.md
@@ -2,15 +2,15 @@
 
 ## 1. Purpose and Intended Outcome
 
-The Validation Assessment tests whether a screened opportunity is strong enough to justify full business analysis.
+The Validation Assessment tests whether a screened opportunity is strong enough to justify focused analysis.
 
-It exists to validate business alignment, test sponsorship, confirm the primary organizational beneficiary, confirm outcomes and success measures, clarify scope boundaries and high-level capabilities, compare conceptual options, and identify obvious kill risks before more effort is invested. A useful Validation Assessment is evidence-based enough to support a stop, defer, or proceed decision without becoming a design pack.
+It exists to validate business alignment, test sponsorship, confirm the primary organizational beneficiary, confirm outcomes and success measures, clarify current state, scope boundaries, stakeholder needs, and high-level requirements, compare conceptual options, and identify obvious kill risks before more effort is invested. A useful Validation Assessment is evidence-based enough to support a stop, defer, or proceed decision without becoming a design pack.
 
-The intended outcome is that only opportunities with credible need, plausible sponsorship, clear organizational value, and manageable risk move into full business analysis.
+The intended outcome is that only opportunities with credible need, plausible sponsorship, clear organizational value, and manageable risk move into focused analysis.
 
 ## 2. When It Is Required
 
-This artifact is required for work that passes the Initial Review and needs a stronger evidence base before deciding whether to invest in full business analysis.
+This artifact is required for work that passes the Initial Review and needs a stronger evidence base before deciding whether to invest in focused analysis.
 
 ## 3. Intended Readers and Users
 
@@ -23,7 +23,7 @@ This artifact is required for work that passes the Initial Review and needs a st
 
 ## 4. Intended Project Context
 
-Use this artifact in the middle of Stage 1 - Work Assessment after the request survives initial triage but before the organization decides whether to do full business analysis.
+Use this artifact in the middle of Work Assessment after the request survives initial triage but before the organization decides whether to do focused analysis.
 
 ## 5. How Much Detail to Include
 
@@ -35,11 +35,11 @@ Include enough detail to answer five practical questions:
 - what must any viable answer be able to do
 - what broad approaches exist
 - what major risks or feasibility concerns are visible now
-- is full business analysis justified
+- is focused analysis justified
 
 The governing principle is:
 
-> Add enough evidence to decide whether full business analysis should happen, but stop short of detailed definition, design, or planning.
+> Add enough evidence to decide whether focused analysis should happen, but stop short of detailed definition, design, or planning.
 
 ## 6. Required Content or Minimum Structure
 
@@ -74,7 +74,7 @@ Where no sponsor is willing to own and advocate for the initiative, treat this a
 
 Must include:
 
-- the relevant current systems, processes, constraints, dependencies, or prior attempts that shape the opportunity
+- the relevant current systems, workflows, constraints, dependencies, or prior attempts that shape the opportunity
 
 ### 6.5. Scope boundaries
 
@@ -84,17 +84,19 @@ Must include:
 - what is clearly out of scope at this stage
 - key assumptions or boundary conditions
 
-### 6.6. Functional capabilities at high level
+### 6.6. High-level requirements and capabilities
 
 Must include:
 
 - a short list of what any viable solution must be able to do
+- any material stakeholder requirements, conditions, or non-negotiables already visible at this stage
 
-Capabilities must be:
+These requirements or capabilities must be:
 
 - outcome-oriented
 - technology-agnostic
 - concise enough to support option comparison
+- light enough to guide later definition without behaving like detailed specifications
 
 ### 6.7. Viable options
 
@@ -131,7 +133,7 @@ Must include one explicit recommendation:
 
 - stop
 - defer
-- proceed to full business analysis
+- proceed to focused analysis
 
 Include rationale and optional relative priority where useful.
 
@@ -155,8 +157,12 @@ Must include:
 - key context to carry forward
 - assumptions that need testing
 - priority risks or constraints
-- stakeholder sensitivities or history that the later business analysis should not rediscover
+- stakeholder sensitivities or history that the later analysis should not rediscover
+- key stakeholder groups and their material needs or requirements to carry forward
 - likely sponsor, Outcome Owner candidate, and Delivery Owner candidate signals where known
+- early signal on whether the work appears likely to remain small enough for a Work Brief or is more likely to require an Initiative Definition Document
+- likely Acceptance Authority or a clear note that acceptance ownership is still unresolved
+- operational or support ownership signals where service impact already appears likely
 
 ## 7. What to Keep Out
 
@@ -173,7 +179,7 @@ Keep the following out of this artifact:
 
 This artifact builds on the [Initial Review](initial_review_specification.md).
 
-If the item proceeds, it authorizes full business analysis and provides input to the later [Work Assessment Report](work_assessment_report_specification.md).
+If the item proceeds, it justifies focused analysis and provides input to the later [Work Assessment Report](work_assessment_report_specification.md).
 
 ## 9. Ownership, Review, and Acceptance Expectations
 
@@ -187,11 +193,11 @@ This artifact is usually stable once the recommendation and decision are recorde
 
 ## 11. Validation Guide
 
-- Is the need validated enough to justify or reject full business analysis?
+- Is the need validated enough to justify or reject focused analysis?
 - Is business alignment clear?
 - Is there a willing sponsor, or is the lack of sponsorship being treated as a major red flag?
-- Are the primary organizational beneficiary, desired outcomes, success measures, and scope boundaries visible?
-- Are the capabilities outcome-oriented and free of design detail?
+- Are the primary organizational beneficiary, desired outcomes, success measures, scope boundaries, and current-state constraints visible?
+- Are the high-level requirements or capabilities outcome-oriented and free of design detail?
 - Are credible options compared, including doing nothing?
 - Are major risk and feasibility concerns visible?
 - Does the recommendation clearly state whether the item should stop, defer, or proceed?
@@ -201,17 +207,17 @@ This artifact is usually stable once the recommendation and decision are recorde
 ### 12.1. Starter prompt
 
 > Draft a Validation Assessment for a proposed work item that has passed initial triage.
-> Validate business alignment, sponsorship, the primary organizational beneficiary, desired outcomes, success measures, scope boundaries, high-level capabilities, viable options, major risk and feasibility signals, cost of inaction, and a clear recommendation to stop, defer, or proceed to full business analysis.
+> Validate business alignment, sponsorship, the primary organizational beneficiary, desired outcomes, success measures, current state, scope boundaries, stakeholder needs, high-level requirements or capabilities, viable options, major risk and feasibility signals, cost of inaction, and a clear recommendation to stop, defer, or proceed to focused analysis.
 > Keep it evidence-based, practical, and free of detailed design or delivery planning.
 
 ### 12.2. Section prompts
 
-> Rewrite the high-level capabilities so they describe what a viable solution must do without naming technology, implementation detail, or vendor choices.
+> Rewrite the high-level requirements or capabilities so they describe what a viable solution must do without naming technology, implementation detail, or vendor choices.
 
 > Compare the conceptual options in a short table that includes advantages, drawbacks, and the do-nothing option.
 
 ### 12.3. Validation prompts
 
-> Check whether this Validation Assessment supports an evidence-based decision on whether full business analysis should happen without drifting into Work Definition.
+> Check whether this Validation Assessment supports an evidence-based decision on whether focused analysis should happen without drifting into Work Definition.
 
 > Rewrite any section that behaves like a requirement set, design brief, or implementation plan.

--- a/work delivery/work_assessment/work_assessment_process.md
+++ b/work delivery/work_assessment/work_assessment_process.md
@@ -25,28 +25,29 @@
 
 Use this guide when a request, problem, risk, or opportunity needs to be screened before Work Definition begins.
 
-This process sits inside **Stage 1 - Work Assessment** of the [Work Delivery Framework](../work_delivery_framework.md). It gives practitioners a practical way to stop weak work early, deepen scrutiny only where justified, and pass forward only the work that is worth defining.
+This process gives practitioners a practical way to stop weak work early, deepen scrutiny only where justified, and pass forward only the work that is worth defining.
 
 Follow this order:
 
 1. Complete the [Initial Review](initial_review_specification.md) as a quick IT-side sanity check on whether the request is worth more time and broadly aligns with what the organization does.
-2. Complete the [Validation Assessment](validation_assessment_specification.md) with the requester's subject matter experts and immediate team to decide whether full business analysis is justified.
-3. Complete the [Work Assessment Report](work_assessment_report_specification.md) as the culmination of that full business analysis to decide whether the initiative should enter Work Definition.
+2. Complete the [Validation Assessment](validation_assessment_specification.md) with the requester's subject matter experts and immediate team to decide whether focused analysis is justified and what minimum questions it must answer.
+3. Complete the [Work Assessment Report](work_assessment_report_specification.md) as the culmination of that right-sized analysis to decide whether the initiative should enter Work Definition.
 
 The normal handoff is:
 
 `Work Assessment Report -> Initiative Definition Document`
 
-The report is the final Stage 1 decision basis. The Initiative Definition Document then becomes the formal Stage 2 governance baseline.
+The report is the final work assessment decision basis. The Initiative Definition Document then becomes the normal definition baseline when work proceeds.
 
-For appropriately small governed work, the Stage 2 artifact may be a [Work Brief](../work_brief/work_brief_specification.md) instead of a full Initiative Definition Document.
+For appropriately small governed work, the next definition artifact may be a [Work Brief](../work_brief/work_brief_specification.md) instead of a full Initiative Definition Document.
 
 What this process is for:
 
 - stopping weak or unsupported work early
 - identifying whether deeper definition effort is justified
 - making sponsorship, risk, and timing concerns visible before commitment
-- giving Stage 2 a clean, practical starting point
+- giving definition a clean, practical starting point
+- capturing a small definition-ready baseline so definition does not need to rediscover basic need, current-state, stakeholder, and requirement context
 
 What this process is not for:
 
@@ -57,17 +58,18 @@ What this process is not for:
 
 ## 1. Purpose
 
-This document is the practical operating guide for Stage 1 - Work Assessment.
+This document is the practical operating guide for Work Assessment.
 
 It shows teams how to assess proposed work through three increasing levels of scrutiny so that:
 
 - low-value or weakly supported requests can stop quickly
 - promising work can be tested before deeper effort is invested
-- the final Stage 1 output is decision-ready and usable as input to Work Definition
+- the final output is decision-ready and usable as input to Work Definition
+- only the minimum analysis needed to support a sound work assessment decision and definition handoff is performed
 
 ## 2. Where This Process Fits
 
-This process works inside Stage 1 of the [Work Delivery Framework](../work_delivery_framework.md). It does not replace stage decisions or authorization controls.
+This process can be used on its own as the front-end assessment path for planned work. Where the broader [Work Delivery Framework](../work_delivery_framework.md) is used, it aligns to Work Assessment and feeds Work Definition. It does not replace later decision or authorization controls.
 
 Use it before:
 
@@ -79,9 +81,9 @@ The normal progression is:
 
 `Initial Review -> Validation Assessment -> Work Assessment Report -> Initiative Definition Document`
 
-Stage 1 decides whether the work is worth defining. Stage 2 defines what should actually be authorized.
+This process decides whether the work is worth defining. Work Definition then defines what should actually be authorized.
 
-Proceeding from Stage 1 is not delivery authorization.
+Proceeding from Work Assessment is not delivery authorization.
 
 ## 3. Who Does What
 
@@ -93,7 +95,7 @@ Proceeding from Stage 1 is not delivery authorization.
 | Outcome Owner Candidate | Clarify what meaningful improvement is being sought |
 | ITS Leadership / Intake Governance | Decide whether to stop, defer, or let the work advance |
 | Requester SMEs and Immediate Team | Contribute business context, boundaries, outcomes, and practical constraints during Validation |
-| Business Analysis Leads | Produce the deeper analysis that culminates in the Work Assessment Report |
+| Analysis Lead / Business Analysis Lead | Produce the right-sized analysis that culminates in the Work Assessment Report |
 | Subject Matter Leads | Contribute targeted evidence where risk, support, security, data, operations, or compliance matter |
 
 ## 4. Before You Start
@@ -101,7 +103,7 @@ Proceeding from Stage 1 is not delivery authorization.
 Before drafting a work assessment artifact, make sure you have at least:
 
 - a short description of the request or opportunity
-- the current step inside Stage 1
+- the current step inside Work Assessment
 - the named Assessment Owner
 - the expected decision-maker for the next gate
 - enough source context to avoid pure guesswork
@@ -113,8 +115,8 @@ If these are missing, you can still create a working draft, but label it clearly
 | Step | Minimum inputs | Required outputs | Completion check | Accountable owner |
 | --- | --- | --- | --- | --- |
 | 1. Initial Review | request summary, source, problem signal, basic stakeholder context | Initial Review, initial decision record | the need is understandable, obvious dealbreakers are checked, and the recommendation is explicit | IT Assessment Owner |
-| 2. Validation Assessment | approved Initial Review, requester SME input, basic current-state facts | Validation Assessment, recommendation on whether to do full business analysis | the need is validated, sponsorship is tested, outcomes and scope boundaries are clearer, and the case for full business analysis is explicit | IT Assessment Owner with requester SMEs and sponsor candidate |
-| 3. Work Assessment Report | completed business analysis, validated scope and outcome context, stakeholder position, risk and feasibility view, preferred path | Work Assessment Report, final Stage 1 decision record, Stage 2 handoff notes, recommended Stage 2 starting artifact (Initiative Definition Document or Work Brief) | decision-makers can see whether Work Definition is justified, under what conditions, and what Stage 2 must clarify next | Business analysis lead with sponsor and ITS leadership |
+| 2. Validation Assessment | approved Initial Review, requester SME input, basic current-state facts | Validation Assessment, recommendation on whether to do focused analysis | the need is validated, sponsorship is tested, outcomes and scope boundaries are clearer, and the case for focused analysis is explicit | IT Assessment Owner with requester SMEs and sponsor candidate |
+| 3. Work Assessment Report | completed focused analysis, validated scope and outcome context, stakeholder position, risk and feasibility view, preferred path | Work Assessment Report, final work assessment decision record, handoff notes, recommended next definition artifact (Initiative Definition Document or Work Brief) | decision-makers can see whether Work Definition is justified, under what conditions, and what must be clarified next | Analysis lead with sponsor and ITS leadership |
 
 ## 6. Guided Workflow
 
@@ -149,7 +151,7 @@ Do not:
 ### 6.2. Step 2 - Validation Assessment
 
 Goal:
-Validate that the opportunity is strong enough to justify full business analysis and not obviously blocked by sponsorship, strategy, business alignment, risk, supportability, capability, or funding concerns.
+Validate that the opportunity is strong enough to justify focused analysis and not obviously blocked by sponsorship, strategy, business alignment, risk, supportability, capability, or funding concerns.
 
 Use this spec:
 
@@ -158,15 +160,15 @@ Use this spec:
 Do this:
 
 1. Refine the problem statement using input from the requester's subject matter experts and immediate team.
-2. Confirm organizational alignment, primary beneficiary, desired outcomes, success measures, and scope boundaries.
-3. Describe required capabilities at high level and compare credible conceptual options, including doing nothing.
+2. Confirm organizational alignment, primary beneficiary, desired outcomes, success measures, current-state constraints, key stakeholder needs, and scope boundaries.
+3. Describe high-level requirements or capabilities and compare credible conceptual options, including doing nothing.
 4. Surface major risk and feasibility signals across sponsorship, strategy, security, operations, delivery capability, and funding.
-5. Decide whether full business analysis is justified and record what that analysis must answer if the work proceeds.
+5. Decide whether focused analysis is justified and record what that analysis must answer if the work proceeds.
 
 Produce:
 
 - Validation Assessment
-- recommendation to stop, defer, or proceed to full business analysis
+- recommendation to stop, defer, or proceed to focused analysis
 
 Do not:
 
@@ -177,7 +179,7 @@ Do not:
 ### 6.3. Step 3 - Work Assessment Report
 
 Goal:
-Produce the final Stage 1 assessment and recommendation on whether the work should enter Work Definition, using the completed business analysis as the decision basis.
+Produce the final work assessment and recommendation on whether the work should enter Work Definition, using the completed focused analysis as the decision basis.
 
 Use this spec:
 
@@ -185,18 +187,18 @@ Use this spec:
 
 Do this:
 
-1. Synthesize the business analysis findings, validated need, options, risks, timing, stakeholder position, and likely value.
+1. Synthesize the analysis findings, validated need, current state, stakeholder needs, high-level requirements, options, risks, timing, and likely value.
 2. State the preferred direction clearly, including why that path is better than the alternatives.
 3. Show that there is enough information to make an informed decision to define the initiative and move it toward authorization.
-4. Describe the recommended Stage 2 starting boundary without trying to define the full initiative yet.
-5. Record what Stage 2 must confirm, define, or resolve if work proceeds.
-6. Record the final Stage 1 decision and handoff basis.
+4. Describe the recommended definition starting boundary without trying to define the full initiative yet.
+5. Record what the next definition step must confirm, define, or resolve if work proceeds.
+6. Record the final work assessment decision and handoff basis.
 
 Produce:
 
 - Work Assessment Report
-- final Stage 1 decision record
-- Stage 2 handoff notes
+- final work assessment decision record
+- definition handoff notes
 
 Do not:
 
@@ -212,11 +214,11 @@ Typical working expectations:
 
 - Initial Review: days, not weeks
 - Validation Assessment: usually 1 to 2 weeks
-- Full business analysis and Work Assessment Report: only as much effort as needed to support an informed Stage 1 decision
+- Focused analysis and Work Assessment Report: only as much effort as needed to support an informed work assessment decision and a usable definition starting point
 
 ## 8. Optional Assessment Work Brief
 
-The existing "opportunity assessment work brief" pattern is still useful when the business analysis effort itself needs explicit time-boxing, ownership, or capacity approval.
+The existing "opportunity assessment work brief" pattern is still useful when the assessment effort itself needs explicit time-boxing, ownership, or capacity approval.
 
 Use a short internal work brief only when needed to clarify:
 
@@ -225,22 +227,70 @@ Use a short internal work brief only when needed to clarify:
 - what is in and out of scope for the assessment effort
 - what decision is being requested at the end of the assessment
 
-This is optional support material. It is not one of the three core Stage 1 gating artifacts.
+This is optional support material. It is not one of the three core gating artifacts in this process.
 
 ## 9. Handoff to Work Definition
 
-If the final Stage 1 decision is to proceed, Stage 2 should start from the Work Assessment Report and not re-discover the same basics.
+If the final assessment decision is to proceed, Work Definition should start from the Work Assessment Report and not re-discover the same basics.
 
 At minimum, the handoff should carry forward:
 
 - validated statement of need
 - desired outcomes
+- success measures
 - sponsor and owner candidates
+- preferred title or working label for the item being defined
 - the recommended path or preferred option
+- why that path is the recommended basis for definition
 - major constraints, dependencies, and unresolved questions
-- the specific issues Stage 2 must define before authorization
+- the recommended next definition artifact and why
+- any ownership or authority gaps that definition must close early
+- the specific issues definition must clarify before authorization
 
-Stage 2 then produces the Initiative Definition Document and supporting authorization-level artifacts, or uses a Work Brief where the work is intentionally scaled and still governed.
+Work Assessment should not try to complete the full definition artifact. It should, however, hand over a small definition-ready baseline so definition starts from accepted assessment conclusions rather than rediscovering them.
+
+For work that proceeds, the handoff package should be explicit enough that definition can immediately carry forward:
+
+- the approved problem statement and intended outcome
+- a concise current-state summary covering the systems, workflows, constraints, or prior attempts that materially shape definition
+- the success measures to preserve
+- the key stakeholder groups and their material needs or requirements
+- the high-level requirements or capabilities any viable solution must address
+- the proposed in-scope and out-of-scope boundary
+- the preferred option to define, including the reason for that direction
+- named sponsor, Outcome Owner, Delivery Owner, and Decision Authority signals, or a clear statement of which roles are still unresolved
+- the likely deliverable domains that definition will need to make visible, and which of those domains appear material enough to require authorization-level coverage
+- the assumptions definition must either preserve, validate, or resolve explicitly
+- operational, support, security, privacy, compliance, funding, or dependency concerns that materially shape definition work
+
+### 9.1. Standard definition-ready baseline
+
+Use the following core outputs when a work item is being handed from Work Assessment into Initiative Definition or a Work Brief.
+
+| Core work assessment handoff output | Minimum content | Primary use in definition |
+| --- | --- | --- |
+| Problem / Opportunity Statement | validated need, why it matters now, consequence of inaction | becomes the basis for the Initiative Definition business need and executive summary |
+| Current State Summary | relevant systems, workflows, pain points, constraints, dependencies, or prior attempts | gives definition the current-state context needed for scope, risk, and support discussions |
+| Stakeholders | sponsor and owner signals, affected stakeholder groups, and their material needs | helps definition confirm ownership, acceptance involvement, and change impact early |
+| High-Level Requirements | what any viable answer must achieve, without design detail | gives definition a concise baseline before detailed elaboration starts |
+| Risks / Constraints | material delivery, security, support, funding, compliance, or timing concerns | informs the Initiative Definition risk, dependency, and major-impact view |
+| Assumptions | working assumptions that shape the recommendation and still need confirmation | shows definition what must be validated rather than silently carried forward |
+
+Keep these outputs concise. They are not six separate large documents. In normal use they should be captured inside the Work Assessment Report as the definition-ready baseline.
+
+### 9.2. Deliverable selection guide
+
+Scale the handoff depth to the work, not to a fixed template burden.
+
+| Work profile | Typical signals | Handoff expectation | Normal next definition path |
+| --- | --- | --- | --- |
+| Small / low risk | one team or a narrow change, limited integration, low support or compliance impact, ownership is straightforward | capture the six core outputs briefly inside the Work Assessment Report and keep the recommendation concise | usually a Work Brief |
+| Medium | cross-team coordination, moderate dependency or service impact, some unresolved ownership or acceptance detail | use the standard six-output set in full, with a clear preferred path and explicit open questions for definition | Initiative Definition Document or Work Brief if the work still behaves like one clear governed item |
+| Large / complex | multiple teams, significant data, security, operational, funding, or regulatory impact, or materially uncertain ownership or scope | use the standard six-output set plus expanded analysis only where it changes the decision, definition boundary, or required deliverable domains | Initiative Definition Document |
+
+If additional analysis does not change the recommendation, the definition boundary, the ownership model, or the likely deliverable domains, do not add it just for completeness.
+
+The next definition step then produces the Initiative Definition Document and supporting authorization-level artifacts, or uses a Work Brief where the work is intentionally scaled and still governed.
 
 ## 10. AI-Assisted Authoring Workflow
 
@@ -272,7 +322,7 @@ Good signs:
 
 - work stops early when value or sponsorship is weak
 - the level of effort increases only when the previous step justifies it
-- the Work Assessment Report gives Stage 2 a clean starting point
+- the Work Assessment Report gives definition a clean starting point
 - the recommendation is explicit and attributable
 
 Warning signs:
@@ -280,5 +330,5 @@ Warning signs:
 - every request jumps straight into definition
 - initial screening includes design, requirements, or vendor detail
 - kill risks are visible but ignored
-- Stage 2 is forced to rediscover basic problem, stakeholder, and risk context
+- definition is forced to rediscover basic problem, stakeholder, and risk context
 - "proceed" is treated as approval to deliver

--- a/work delivery/work_assessment/work_assessment_report_form.md
+++ b/work delivery/work_assessment/work_assessment_report_form.md
@@ -1,9 +1,9 @@
 # Work Assessment Report Form
 
-Use this form at the end of Stage 1 - Work Assessment.
+Use this form at the end of Work Assessment.
 
 Purpose:
-Capture the culmination of the full business analysis and make the final recommendation on whether the initiative should enter Work Definition.
+Capture the culmination of the focused analysis and make the final recommendation on whether the initiative should enter Work Definition.
 
 Recommendation options:
 
@@ -19,7 +19,7 @@ Recommendation options:
 
 **Assessment Version / Date:**  
 
-**Assessment Owner / Business Analysis Lead:**  
+**Assessment Owner / Analysis Lead:**  
 
 **Sponsor:**  
 
@@ -33,7 +33,7 @@ Recommendation options:
 
 **Reference to Validation Assessment:**  
 
-**Reference to business analysis basis used:**  
+**Reference to analysis basis used:**  
 
 ---
 
@@ -61,7 +61,7 @@ Summarize the need, the recommendation, and why that recommendation is being mad
 
 ## 4. Assessment Scope Boundary
 
-What appears likely to be in scope for Stage 2 definition, and what is clearly out of scope at this point?
+What appears likely to be in scope for definition, and what is clearly out of scope at this point?
 
 **Likely in scope for Work Definition:**  
 
@@ -91,9 +91,13 @@ What appears likely to be in scope for Stage 2 definition, and what is clearly o
 
 ---
 
-## 6. Business Analysis Findings Summary
+## 6. Current-State, Stakeholder, and Analysis Findings Summary
 
-What did the full business analysis establish that most shapes the recommendation?
+What did the focused analysis establish that most shapes the recommendation?
+
+**Current-state summary:**  
+
+**Key stakeholder groups and their material needs or requirements:**  
 
 **Key findings:**  
 
@@ -101,9 +105,9 @@ What did the full business analysis establish that most shapes the recommendatio
 
 ---
 
-## 7. High-Level Capability and Work Profile Summary
+## 7. High-Level Requirements, Capabilities, and Work Profile Summary
 
-**Key high-level capabilities or outcome areas required:**  
+**Key high-level requirements or capabilities to preserve:**  
 
 **Likely work classification / initiative type:**  
 
@@ -135,20 +139,66 @@ What did the full business analysis establish that most shapes the recommendatio
 
 ---
 
-## 9. Recommended Stage 2 Focus
+## 9. Recommended Definition Focus and Handoff Baseline
 
 If this proceeds, what must Work Definition clarify, confirm, or resolve next?
 
-**Required Stage 2 focus areas:**  
+**Required definition focus areas:**  
 
-**People / roles that must be involved in Stage 2:**  
+**People / roles that must be involved in definition:**  
 
 **Questions that must be resolved before later authorization:**  
 
-**Recommended Stage 2 starting artifact:**
+**Recommended next definition artifact:**
 
 - [ ] Initiative Definition Document
 - [ ] Work Brief (scaled governed work)
+
+**Why this is the right definition artifact:**  
+
+### Carry-forward baseline for definition
+
+These are the assessment conclusions that definition should start from rather than rediscovering.
+
+**Approved statement of need to carry forward:**  
+
+**Current-state summary to carry forward:**  
+
+**Intended outcome and success measures to preserve:**  
+
+**Key stakeholder groups and their material needs to carry forward:**  
+
+**High-level requirements or capabilities to carry forward:**  
+
+**Proposed in-scope and out-of-scope boundary for definition:**  
+
+**Preferred path to define:**  
+
+**Major risks, dependencies, and constraints that already shape definition:**  
+
+**Assumptions definition must preserve, validate, or resolve explicitly:**  
+
+**Likely deliverable domains in scope for definition and why:**  
+
+**Which domains appear material enough for authorization-level visibility in definition:**  
+
+**Likely Acceptance Authority signals by domain or deliverable grouping:**  
+
+### Ownership and authority readiness for definition
+
+**Named sponsor for definition:**  
+
+**Outcome Owner signal:**  
+
+**Delivery Owner signal:**  
+
+**Decision Authority for later authorization:**  
+
+**Acceptance Authority signal or ownership gap:**  
+
+**Operational / support owner signals if materially relevant:**  
+
+**Unresolved ownership or authority gaps definition must close early:**  
 
 ---
 
@@ -190,7 +240,7 @@ If this proceeds, what must Work Definition clarify, confirm, or resolve next?
 
 ## 12. Handoff References
 
-List the key supporting records that Stage 2 should use.
+List the key supporting records that definition should use.
 
 **Upstream assessment references:**  
 

--- a/work delivery/work_assessment/work_assessment_report_specification.md
+++ b/work delivery/work_assessment/work_assessment_report_specification.md
@@ -2,15 +2,15 @@
 
 ## 1. Purpose and Intended Outcome
 
-The Work Assessment Report is the final Stage 1 assessment artifact and the culmination of the full business analysis. It recommends whether the proposed work should enter Work Definition and records the rationale, conditions, and handoff basis for that decision.
+The Work Assessment Report is the final work assessment artifact and the culmination of the focused analysis. It recommends whether the proposed work should enter Work Definition and records the rationale, conditions, and handoff basis for that decision.
 
-It exists to synthesize the earlier screening work and the completed business analysis into one decision-ready view for leadership and governance reviewers. A useful Work Assessment Report is stronger than a triage note but lighter than an Initiative Definition Document. It should make the recommended path, major implications, and next-step expectations clear without turning into authorization content or detailed design.
+It exists to synthesize the earlier screening work and the completed analysis into one decision-ready view for leadership and governance reviewers. A useful Work Assessment Report is stronger than a triage note but lighter than an Initiative Definition Document. It should make the recommended path, major implications, and next-step expectations clear without turning into authorization content or detailed design.
 
 The intended outcome is that the organization has enough information to make an informed decision to define the initiative and move it forward toward authorization, or to stop or defer it with a practical, traceable basis.
 
 ## 2. When It Is Required
 
-This artifact is required for work that passes Validation Assessment and completes full business analysis before the final Stage 1 decision is made.
+This artifact is required for work that passes Validation Assessment and completes focused analysis before the final work assessment decision is made.
 
 ## 3. Intended Readers and Users
 
@@ -19,13 +19,13 @@ This artifact is required for work that passes Validation Assessment and complet
 - ITS leadership
 - Outcome Owner candidate
 - Delivery Owner candidate
-- practitioners preparing Stage 2 definition artifacts
+- practitioners preparing definition artifacts
 
 ## 4. Intended Project Context
 
-Use this artifact at the end of Stage 1 - Work Assessment.
+Use this artifact at the end of Work Assessment.
 
-This document should bridge business analysis and definition. It should not replace the Initiative Definition Document or the Project Charter.
+This document should bridge work assessment and definition. It should not replace the Initiative Definition Document or the Project Charter.
 
 ## 5. How Much Detail to Include
 
@@ -34,12 +34,14 @@ Include enough detail to support a sound decision on whether Work Definition sho
 At minimum, the report should make visible:
 
 - what need has been validated
+- what current-state context and stakeholder needs materially shape the work
 - what outcome and success measures are being pursued
-- what the business analysis found
+- what the analysis found
+- what high-level requirements or capabilities any viable answer must address
 - what broad options were considered
 - what path is recommended and why
 - what material risks, dependencies, and constraints exist
-- what Stage 2 must define if the work proceeds
+- what definition must clarify if the work proceeds
 
 The governing principle is:
 
@@ -59,7 +61,7 @@ Must include:
 - Delivery Owner candidate where known
 - intended decision authority
 - references to the Initial Review and Validation Assessment
-- reference to the business analysis basis used
+- reference to the analysis basis used
 
 ### 6.2. Executive summary
 
@@ -83,7 +85,7 @@ Must include:
 
 Must include:
 
-- what this assessment concluded is likely in scope for Stage 2 definition
+- what this assessment concluded is likely in scope for definition
 - what is clearly out of scope at this point
 - key assumptions and constraints
 
@@ -97,18 +99,20 @@ Must include:
 - the preferred path
 - why the preferred path is better than the alternatives at this stage
 
-### 6.6. Business analysis findings summary
+### 6.6. Current-state, stakeholder, and analysis findings summary
 
 Must include:
 
-- the key findings from the full business analysis
+- a concise current-state summary including the systems, workflows, constraints, dependencies, or prior attempts that materially shape the recommendation
+- the key stakeholder groups and their material needs or requirements
+- the key findings from the focused analysis
 - the important assumptions, evidence points, or conclusions that shape the recommendation
 
-### 6.7. High-level capability and work profile summary
+### 6.7. High-level requirements, capabilities, and work profile summary
 
 Must include:
 
-- the key high-level capabilities or outcome areas the work would need to address
+- the key high-level requirements or capabilities the work would need to address
 - likely work classification or initiative type where helpful
 - rough indication of whether the work appears small, medium, or large in governance terms
 
@@ -120,16 +124,34 @@ Must include:
 - key dependencies and timing constraints
 - sponsorship, funding, supportability, security, privacy, regulatory, or organizational readiness concerns that matter to the recommendation
 
-### 6.9. Recommended Stage 2 focus
+### 6.9. Recommended definition focus and handoff baseline
 
 Must include:
 
 - what Work Definition must clarify or confirm next
-- likely owner or stakeholder involvement needed in Stage 2
+- likely owner or stakeholder involvement needed in definition
 - any gating questions that must be resolved before Work Authorization could be considered later
-- recommended Stage 2 starting artifact: Initiative Definition Document or Work Brief for appropriately small governed work
+- recommended next definition artifact: Initiative Definition Document or Work Brief for appropriately small governed work
+- why that definition artifact is the right governance fit
+- the carry-forward baseline that definition should start from without re-analysis:
+  - approved statement of need
+  - concise current-state summary
+  - intended outcome and success measures to preserve
+  - key stakeholder groups and their material needs or requirements
+  - high-level requirements or capabilities to preserve
+  - proposed in-scope and out-of-scope boundary
+  - preferred path to define
+  - major risks, dependencies, and constraints that already shape definition
+  - assumptions that definition must preserve, validate, or resolve explicitly
+- the likely deliverable domains that appear to be in scope for definition, with a short reason for each
+- which of those domains appear material enough to require authorization-level visibility in definition, and which can likely remain summary-level until later elaboration
+- likely Acceptance Authority signals for the relevant deliverable domains or deliverable groupings where visible
+- named sponsor, Outcome Owner, Delivery Owner, Decision Authority, and Acceptance Authority signals where known, or an explicit statement of which of these still remain unresolved
+- any operational, support, financial, or service-ownership implications that definition must treat as inputs rather than rediscovering from scratch
 
-This section is the bridge into the Initiative Definition Document.
+This section is the bridge into Initiative Definition or a Work Brief.
+
+The goal is not to finish definition inside Work Assessment. The goal is to give definition an explicit starting baseline and an explicit list of open definition decisions.
 
 ### 6.10. Work assessment recommendation
 
@@ -172,48 +194,50 @@ Keep the following out of this artifact:
 
 ## 8. Relationships to Other Artifacts
 
-This artifact builds on the [Initial Review](initial_review_specification.md), the [Validation Assessment](validation_assessment_specification.md), and the full business analysis completed after validation.
+This artifact builds on the [Initial Review](initial_review_specification.md), the [Validation Assessment](validation_assessment_specification.md), and the focused analysis completed after validation.
 
 If the final decision is to proceed, it becomes a primary input to:
 
-- [Work Delivery Framework Stage 2](../work_delivery_framework.md)
+- [Work Delivery Framework](../work_delivery_framework.md)
 - [Initiative Definition Document Specification](../governance_and_control_deliverables/initiative_definition_document_specification.md)
 
 ## 9. Ownership, Review, and Acceptance Expectations
 
-The Assessment Owner or business analysis lead usually coordinates this document with input from the sponsor, key stakeholders, and ITS leadership.
+The Assessment Owner or analysis lead usually coordinates this document with input from the sponsor, key stakeholders, and ITS leadership.
 
-The final Stage 1 decision should be confirmed by the relevant decision authority or delegated governance body before Stage 2 begins.
+The final work assessment decision should be confirmed by the relevant decision authority or delegated governance body before definition begins.
 
 ## 10. Maintenance Expectations
 
-This artifact is normally stable once the Stage 1 decision is recorded. If the work is deferred and later revisited, either update the report or issue a new version so the changed basis is visible.
+This artifact is normally stable once the assessment decision is recorded. If the work is deferred and later revisited, either update the report or issue a new version so the changed basis is visible.
 
 ## 11. Validation Guide
 
 - Does the report make a clear recommendation on whether Work Definition should begin?
-- Does it clearly reflect the findings of the full business analysis?
+- Does it clearly reflect the findings of the focused analysis?
 - Can a decision-maker understand the need, preferred path, and major concerns quickly?
+- Are current-state context, stakeholder needs, and high-level requirements visible enough to support definition without rediscovery?
 - Does it stop short of becoming an Initiative Definition Document or Project Charter?
 - Are the main risks, dependencies, and conditions visible enough to guide the next step?
-- Does Stage 2 have a clear handoff basis if the recommendation is to proceed?
+- Does definition have a clear handoff basis if the recommendation is to proceed?
+- Does the definition section clearly separate what should be carried forward as baseline input from what still needs to be defined or confirmed?
 
 ## 12. Prompt Guide for Drafting the Artifact
 
 ### 12.1. Starter prompt
 
-> Draft a Work Assessment Report that synthesizes the Initial Review, Validation Assessment, and completed business analysis into a final Stage 1 recommendation.
-> Explain the validated need, desired outcomes, success measures, business analysis findings, preferred path, major risks and dependencies, and what Work Definition must clarify next.
+> Draft a Work Assessment Report that synthesizes the Initial Review, Validation Assessment, and completed focused analysis into a final assessment recommendation.
+> Explain the validated need, current state, stakeholder needs, desired outcomes, success measures, high-level requirements or capabilities, analysis findings, preferred path, major risks and dependencies, and what Work Definition must clarify next.
 > Keep it decision-ready, practical, and lighter than an Initiative Definition Document.
 
 ### 12.2. Section prompts
 
 > Write the preferred-path section so it explains why the recommended option is better than the alternatives at this stage, including the do-nothing option.
 
-> Draft the Stage 2 focus section so the next team can see what must be clarified, who needs to be involved, and what questions remain open.
+> Draft the definition-focus section so the next team can see what must be carried forward as the starting baseline, what still must be clarified, who needs to be involved, and what questions remain open.
 
 ### 12.3. Validation prompts
 
-> Check whether this report works as the final Stage 1 decision artifact and handoff basis without drifting into Work Definition or authorization.
+> Check whether this report works as the final work assessment decision artifact and handoff basis without drifting into Work Definition or authorization.
 
 > Rewrite any section that behaves like an approved scope baseline, project charter, or design brief.

--- a/work delivery/work_assessment/work_assessment_to_initiative_definition_alignment.md
+++ b/work delivery/work_assessment/work_assessment_to_initiative_definition_alignment.md
@@ -1,0 +1,71 @@
+# Work Assessment to Initiative Definition Alignment
+
+## 1. Purpose
+
+This note records the review of the current Work Assessment process and the targeted improvements made to support a smoother, lighter transition into Initiative Definition.
+
+The intent is to improve the existing process, not replace it.
+
+## 2. What Already Works
+
+The current process already has a strong base:
+
+- the three-step assessment path is clear and scalable
+- Work Assessment and Initiative Definition are already separated cleanly
+- the Work Brief path already provides a scaled option for smaller governed work
+- the Work Assessment Report is already positioned as the handoff artifact into Initiative Definition
+
+These strengths mean the process does not need redesign. It needs tighter handoff discipline and lighter, more explicit carry-forward content.
+
+## 3. Gap Analysis and Improvement Areas
+
+| Gap observed in the current process | Why it matters | Improvement applied |
+| --- | --- | --- |
+| Work Assessment language leans heavily on "full business analysis" | this can imply more analysis than many work items need and can slow intake unnecessarily | reframed Work Assessment as focused, right-sized analysis tied to the decision and handoff need |
+| The Work Assessment to Initiative Definition handoff exists, but the minimum carry-forward content is not standardized enough | Initiative Definition can end up rediscovering problem, current-state, stakeholder, and requirement basics | defined a six-part definition-ready baseline to carry forward explicitly |
+| Current-state, stakeholder context, and high-level requirements are present, but scattered across the artifacts | important inputs for Initiative Definition can be missed or buried in narrative sections | made these items more explicit in the Validation Assessment and Work Assessment Report expectations |
+| The process distinguishes Work Brief and Initiative Definition, but the scaling logic between them is still easy to interpret inconsistently | teams may over-document small work or under-prepare more complex work | added a lightweight deliverable selection guide based on size and complexity |
+| Initiative Definition open questions and accepted assessment conclusions are not always separated clearly | definition can either repeat analysis or treat assumptions as settled facts | strengthened the handoff baseline so preserved inputs and unresolved definition questions are both visible |
+
+## 4. Standard Deliverable Set for the Work Assessment Handoff
+
+The recommended standard set is:
+
+- Problem / Opportunity Statement
+- Current State Summary
+- Stakeholders
+- High-Level Requirements
+- Risks / Constraints
+- Assumptions
+
+This is a baseline content set, not a requirement to create six separate documents. For most work, these should be captured inside the Work Assessment Report.
+
+## 5. Mapping to Initiative Definition Needs
+
+| Work Assessment baseline output | Why it exists | Main Initiative Definition use |
+| --- | --- | --- |
+| Problem / Opportunity Statement | keeps the validated need stable between stages | business need and rationale, executive summary |
+| Current State Summary | shows what exists now and what constrains change | current-state context for scope, risk, support, and future-state intent |
+| Stakeholders | shows who is affected, who may own the outcome, and whose needs matter | ownership confirmation, acceptance involvement, operational and change impact visibility |
+| High-Level Requirements | states what a viable initiative must achieve without entering design detail | scope boundary, approval-level capability definition, downstream Functional Capabilities input where needed |
+| Risks / Constraints | shows what may block, shape, or condition the initiative | key risks, dependencies, and major impacts |
+| Assumptions | makes working assumptions explicit before authorization | scope boundaries, risk visibility, and definition validation needs |
+
+## 6. Lightweight Selection Logic
+
+Use the minimum depth that still supports a sound assessment decision and a usable definition start.
+
+| Work profile | Use this depth | Practical expectation |
+| --- | --- | --- |
+| Small / low risk | Minimal | capture the standard set briefly, prefer concise narrative, and usually hand off to a Work Brief |
+| Medium | Standard | complete the full standard set and make the preferred path, owners, and open definition questions explicit |
+| Large / complex | Expanded only where needed | keep the standard set, then deepen analysis only for the areas that materially affect decision, scope, ownership, or deliverable selection |
+
+## 7. Resulting Operating Change
+
+The practical change is simple:
+
+- Work Assessment stays a three-step process
+- the analysis remains right-sized
+- the Work Assessment Report becomes the explicit definition-ready baseline
+- Initiative Definition starts from accepted assessment conclusions instead of rediscovering them

--- a/work delivery/work_brief/work_brief_specification.md
+++ b/work delivery/work_brief/work_brief_specification.md
@@ -14,6 +14,16 @@ Use a Work Brief when the work is small enough to manage as one item, but import
 
 For standalone governed work, the brief should normally be created from the completed Stage 1 assessment output rather than from raw intake notes.
 
+For that reason, Stage 2 should normally carry forward the validated need, intended outcome, success measures, scope boundary, preferred path, key risks, key dependencies, and owner signals already established in Stage 1.
+
+Stage 2 does not need to rediscover those basics. It does need to confirm, complete, and formalize the work-level control details that assessment may only indicate at signal level, especially:
+
+- Acceptance Authority
+- deliverables and acceptance evidence
+- parent or child governance position
+- operational and support ownership where relevant
+- any approval conditions that must become explicit before delivery starts
+
 Within the Work Delivery Framework, it is mainly used as:
 
 - a scaled Stage 2 Work Definition artifact for small governed work


### PR DESCRIPTION
## Summary
- reframe Work Assessment as a standalone process rather than primarily a Stage 1 activity
- tighten Initial Review, Validation Assessment, and Work Assessment Report so they capture lightweight current-state, stakeholder, and high-level requirement inputs
- standardize a concise definition-ready baseline and add simple selection guidance for scaling deliverables
- align the handoff into Initiative Definition and Work Brief with clearer ownership, assumptions, and next-step expectations
- add an alignment note documenting gaps, improvement areas, and mapping to Initiative Definition needs

## Testing
- Not run (not requested)